### PR TITLE
fix: resolve cache path validation error in GitHub Actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,17 @@ inputs:
   username:
     description: GitHub username to generate the activity graph for.
     required: true
+
   options:
     description: Options for the card (query string or JSON).
     required: false
     default: ""
+
   output_path:
     description: Output path for SVG file (relative path; include filename with .svg).
     required: false
     default: ""
+
   token:
     description: GitHub token (PAT or GITHUB_TOKEN). Falls back to github.token if not provided.
     required: false
@@ -27,16 +30,41 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install pnpm
+    - name: Check lockfile
+      shell: bash
+      run: |
+        LOCKFILE="${{ github.action_path }}/pnpm-lock.yaml"
+
+        if [ -f "$LOCKFILE" ]; then
+          echo "lockfile exists"
+          echo "full path: $LOCKFILE"
+        else
+          echo "lockfile missing"
+        fi
+
+    - name: Setup pnpm
       uses: pnpm/action-setup@v5
       with:
         version: 10.12.4
-        cache: true
 
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
         node-version: "24"
+
+    - name: Resolve pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: |
+        echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - name: Cache pnpm store
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -53,6 +81,7 @@ runs:
         INPUT_OPTIONS: ${{ inputs.options }}
         INPUT_OUTPUT_PATH: ${{ inputs.output_path }}
         TOKEN: ${{ inputs.token || github.token }}
+
 branding:
   icon: bar-chart-2
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
       uses: pnpm/action-setup@v6
       with:
         version: 10.12.4
-
+        cache: true
+        
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:

--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,11 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v5
       with:
         version: 10.12.4
         cache: true
-        
+
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Cache pnpm modules
-      uses: actions/cache@v6
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ hashFiles(format('{0}/pnpm-lock.yaml', github.action_path)) }}
-        restore-keys: ${{ runner.os }}-pnpm-
-
     - name: Install pnpm
       uses: pnpm/action-setup@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
       with:
         version: 10.12.4
 

--- a/action.yml
+++ b/action.yml
@@ -30,20 +30,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Check lockfile
-      shell: bash
-      run: |
-        LOCKFILE="${{ github.action_path }}/pnpm-lock.yaml"
-
-        if [ -f "$LOCKFILE" ]; then
-          echo "lockfile exists"
-          echo "full path: $LOCKFILE"
-        else
-          echo "lockfile missing"
-        fi
-
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
       with:
         version: 10.12.4
 
@@ -52,16 +40,14 @@ runs:
       with:
         node-version: "24"
 
-    - name: Resolve pnpm store path
-      id: pnpm-store
+    - name: Configure pnpm store
       shell: bash
-      run: |
-        echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      run: pnpm config set store-dir ~/.pnpm-store
 
     - name: Cache pnpm store
       uses: actions/cache@v6
       with:
-        path: ${{ steps.pnpm-store.outputs.path }}
+        path: ~/.pnpm-store
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Cache pnpm modules
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.pnpm-store
         key: ${{ runner.os }}-pnpm-${{ hashFiles(format('{0}/pnpm-lock.yaml', github.action_path)) }}


### PR DESCRIPTION
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4.

Reference:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/